### PR TITLE
Chore: modify duplicate headers (remove markdown ignores)

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,0 +1,38 @@
+name: Pre-commit auto-update
+
+on:
+  # every sunday at midnight GMT
+  schedule:
+    - cron: "0 0 * * 0"
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  pre-commit-auto-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          labels: |
+            dependencies
+            maintenance
+          body: Update versions of pre-commit hooks to latest version.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,1 @@
+{ "MD024": { siblings_only: true }, "MD013": false }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,25 +6,23 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.8.5"
+    rev: "v0.9.9"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint-fix
-        # MD013: line too long
-        args: [--disable, MD013, "--"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.2
     hooks:
       - id: check-dependabot
         args: ["--verbose"]
@@ -32,6 +30,6 @@ repos:
         args: ["--verbose"]
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.17.0
+    rev: v8.17.3
     hooks:
       - id: cspell

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -15,6 +15,7 @@ words:
   - interpretability
   - soo-shee
 ignoreWords:
+  - autoupdate
   - actants
   - actioned
   - adeu

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD024 -->
 # Analytics
 
 There is a need in data management for effective and sufficiently comprehensive analytics. As part of data processing, analytics produces consistent profiles for data that acts as a series of benchmark tests for the data model prior to integration. Analytics provides consumers of integration endpoints essential information on the model features and structures. This analytic output, stored in the data catalog, allows an institution's internal customers to make rapid assessments for additional data management requirements while making code and tool reuse simpler to assess and implement throughout the data management system.
@@ -38,7 +37,7 @@ These are the roles currently associated with data analytics practices:
 
 Refer to the content management documents for analytics roles on different information systems, specific data architectures, and their associated policies and restrictions.
 
-### Analytics
+### Analytics Metrics and Dimensions
 
 Due to the diversity of data assets handled by institutions across numerous projects and information systems, analytics will vary in form and approach. However, there are essential elements that need to be captured about the quality and effectiveness of the data management system as it exists within its particular data architecture. Analytics should pursue metrics on these dimensions:
 

--- a/docs/appendix_a.md
+++ b/docs/appendix_a.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable MD024 -->
-
 # Appendix - Templates and Rubrics
 
 ## Appendix A. Methodology

--- a/docs/appendix_b.md
+++ b/docs/appendix_b.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD024 -->
 # Appendix - Data Strategy
 
 ## Templates


### PR DESCRIPTION
This pull request includes changes to configuration files and documentation updates. The most important changes involve updating pre-commit hooks to newer versions and making adjustments to markdown linting rules.

Configuration updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L9-R33): Updated the versions of several pre-commit hooks, including `black`, `ruff`, `markdownlint-cli`, `check-jsonschema`, and `cspell-cli`.

Markdown linting adjustments:

* [`.markdownlint.yaml`](diffhunk://#diff-39aecbc26791dd03b9a4fdc1f856769ea73308294b7111d70f279ac9bdef35bdR1): Added a configuration to enable `MD024` rule only for siblings and disabled the `MD013` rule.
* `docs/analytics.md`, `docs/appendix_a.md`, `docs/appendix_b.md`: Removed `markdownlint-disable MD024` comments. [[1]](diffhunk://#diff-82938326b09c41ab47a28382ec2e7656c6f3f9fbed966cffdb6330e45aa7c2b8L1) [[2]](diffhunk://#diff-a877549a05a70c38f9da775515f5a1c9678e48f9f33ae0d4181f14884b6b1239L1-L2) [[3]](diffhunk://#diff-184934e052a0b9f60a5ac3710f53372dc6188dfdbb7cd6507079ab1388147704L1)
* [`docs/analytics.md`](diffhunk://#diff-82938326b09c41ab47a28382ec2e7656c6f3f9fbed966cffdb6330e45aa7c2b8L41-R40): Changed the heading from "Analytics" to "Analytics Metrics and Dimensions" to better reflect the content.